### PR TITLE
ENH expose timeout checker params

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -363,9 +363,8 @@ class RayPPOTrainer(object):
 
         # assert torch.cuda.is_available(), 'cuda must be available on driver'
         self.timeout = TimeoutChecker(
-            initial_interval_hours=config.trainer.get('timeout_hours', 4),
-            backoff_minutes=config.trainer.get('timeout_backoff_minutes', 15),
-            )
+            timeout=config.trainer.get('timeout', '00:03:45:00') # three hours and 45 minutes
+        )
         self.tokenizer = tokenizer
         self.config = config
         self.reward_fn = reward_fn

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -362,7 +362,10 @@ class RayPPOTrainer(object):
                  val_reward_fn=None):
 
         # assert torch.cuda.is_available(), 'cuda must be available on driver'
-        self.timeout = TimeoutChecker()
+        self.timeout = TimeoutChecker(
+            initial_interval_hours=config.trainer.get('timeout_hours', 4),
+            backoff_minutes=config.trainer.get('timeout_backoff_minutes', 15),
+            )
         self.tokenizer = tokenizer
         self.config = config
         self.reward_fn = reward_fn

--- a/verl/utils/timer.py
+++ b/verl/utils/timer.py
@@ -1,10 +1,20 @@
 import time
 import sys
 
+def convert_to_seconds(time_string):
+    # Split the string into components
+    days, hours, minutes, seconds = map(int, time_string.split(':'))
+
+    # Calculate total seconds
+    total_seconds = days * 86400 + hours * 3600 + minutes * 60 + seconds
+
+    return total_seconds
+
+
 class TimeoutChecker:
-    def __init__(self, initial_interval_hours=4, backoff_minutes=15):
+    def __init__(self, timeout: str = '00:03:45:00'):
         super().__init__()
-        self.last_save_time = initial_interval_hours * 3600 - backoff_minutes * 60
+        self.last_save_time = convert_to_seconds(timeout)
         self.start_time = time.time()
         self.last_saved = False
 


### PR DESCRIPTION
Updates the timeout checker to take a `dd:hh:mm:ss` string and exposes it to the config level
```
++trainer.timeout=00:03:45:00
```