### PR TITLE
DAPO integration

### DIFF
--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -84,7 +84,7 @@ def union_tensor_dict(tensor_dict1: TensorDict, tensor_dict2: TensorDict) -> Ten
     return tensor_dict1
 
 
-def union_numpy_dict(tensor_dict1: dict[np.ndarray], tensor_dict2: dict[np.ndarray]) -> dict[np.ndarray]:
+def union_numpy_dict(tensor_dict1: dict[str, np.ndarray], tensor_dict2: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
     for key, val in tensor_dict2.items():
         if key in tensor_dict1:
             assert isinstance(tensor_dict2[key], np.ndarray)
@@ -195,9 +195,38 @@ class DataProto:
             return 0
 
     def __getitem__(self, item):
-        tensor_data = self.batch[item]
-        non_tensor_data = {key: val[item] for key, val in self.non_tensor_batch.items()}
-        return DataProtoItem(batch=tensor_data, non_tensor_batch=non_tensor_data, meta_info=self.meta_info)
+        """
+        Enhanced indexing for DataProto objects.
+        
+        Args:
+            item: Can be one of:
+                - int: A single index
+                - slice: A slice object (start:stop:step)
+                - list: A list of indices
+                - numpy.ndarray: An array of indices
+                - torch.Tensor: A tensor of indices
+                
+        Returns:
+            DataProto: For all indexing types except single integers
+            DataProtoItem: Only for single integer indices
+        """
+        # Case 1: Slice object - use the slice method
+        if isinstance(item, slice):
+            return self.slice(item.start, item.stop, item.step)
+
+        # Case 2: List, numpy array, or torch tensor - use sel_idxs
+        elif isinstance(item, (list, np.ndarray, torch.Tensor)):
+            return self.select_idxs(item)
+
+        # Case 3: Single integer - return DataProtoItem for backward compatibility
+        elif isinstance(item, (int, np.integer)):
+            tensor_data = self.batch[item]
+            non_tensor_data = {key: val[item] for key, val in self.non_tensor_batch.items()}
+            return DataProtoItem(batch=tensor_data, non_tensor_batch=non_tensor_data, meta_info=self.meta_info)
+
+        # Case 4: Unsupported type
+        else:
+            raise TypeError(f"Indexing with {type(item)} is not supported")
 
     def __getstate__(self):
         import io
@@ -266,7 +295,7 @@ class DataProto:
             for key, val in self.non_tensor_batch.items():
                 assert isinstance(
                     val, np.ndarray
-                ) and val.dtype == object, 'data in the non_tensor_batch must be a numpy.array with dtype=object'
+                ), f'data in the non_tensor_batch must be a numpy.array with dtype=object, but for {key=}, got {type(val)=}'
                 assert val.shape[
                     0] == batch_size, f'key {key} length {len(val)} is not equal to batch size {batch_size}'
 
@@ -370,6 +399,87 @@ class DataProto:
 
         return DataProto(batch=sub_batch, non_tensor_batch=non_tensor_batch, meta_info=sub_meta_info)
 
+    def select_idxs(self, idxs):
+        """
+        Select specific indices from the DataProto.
+        
+        Args:
+            idxs (torch.Tensor or numpy.ndarray or list): Indices to select
+            
+        Returns:
+            DataProto: A new DataProto containing only the selected indices
+        """
+        if isinstance(idxs, list):
+            idxs = torch.tensor(idxs, dtype=torch.int32)
+
+        if isinstance(idxs, np.ndarray):
+            idxs_np = idxs
+            idxs_torch = torch.from_numpy(idxs)
+        else:  # torch.Tensor
+            idxs_torch = idxs
+            idxs_np = idxs.detach().cpu().numpy()
+
+        if self.batch is not None:
+            # Use TensorDict's built-in indexing capabilities
+            selected_batch = TensorDict(source={
+                key: tensor[idxs_torch] for key, tensor in self.batch.items()
+            },
+                                        batch_size=(idxs_torch.shape[0],))
+        else:
+            selected_batch = None
+
+        selected_non_tensor = {}
+        for key, val in self.non_tensor_batch.items():
+            selected_non_tensor[key] = val[idxs_np]
+
+        return DataProto(batch=selected_batch, non_tensor_batch=selected_non_tensor, meta_info=self.meta_info)
+
+    def slice(self, start=None, end=None, step=None):
+        """
+        Slice the DataProto and return a new DataProto object.
+        This is an improved version of direct slicing which returns a DataProtoItem.
+        
+        Args:
+            start (int, optional): Start index. Defaults to None (start from beginning).
+            end (int, optional): End index (exclusive). Defaults to None (go to end).
+            step (int, optional): Step size. Defaults to None (step=1).
+            
+        Returns:
+            DataProto: A new DataProto containing the sliced data
+            
+        Examples:
+            # Using the slice method directly
+            sliced_data = data_proto.slice(10, 20)
+            
+            # Using enhanced indexing (returns DataProto)
+            sliced_data = data_proto[10:20]
+            sliced_data = data_proto[::2]  # Every other element
+            
+            # Using list indexing (returns DataProto)
+            indices = [1, 5, 10]
+            selected_data = data_proto[indices]
+            
+            # Single index still returns DataProtoItem
+            single_item = data_proto[5]
+        """
+        # Create a slice object
+        slice_obj = slice(start, end, step)
+
+        # Handle the batch data
+        if self.batch is not None:
+            # Use TensorDict's built-in slicing capabilities
+            sliced_batch = self.batch[slice_obj]
+        else:
+            sliced_batch = None
+
+        # Handle the non-tensor batch data
+        sliced_non_tensor = {}
+        for key, val in self.non_tensor_batch.items():
+            sliced_non_tensor[key] = val[slice_obj]
+
+        # Return a new DataProto object
+        return DataProto(batch=sliced_batch, non_tensor_batch=sliced_non_tensor, meta_info=self.meta_info)
+
     def pop(self, batch_keys=None, non_tensor_batch_keys=None, meta_info_keys=None) -> 'DataProto':
         """Pop a subset of the DataProto via `batch_keys` and `meta_info_keys`
 
@@ -448,19 +558,17 @@ class DataProto:
         return self
 
     def make_iterator(self, mini_batch_size, epochs, seed=None, dataloader_kwargs=None):
-        """Make an iterator from the DataProto. This is built upon that TensorDict can be used as a normal Pytorch
+        r"""Make an iterator from the DataProto. This is built upon that TensorDict can be used as a normal Pytorch
         dataset. See https://pytorch.org/tensordict/tutorials/data_fashion for more details.
 
+
         Args:
-            mini_batch_size (int): mini-batch size when iterating the dataset. We require that
-                ``batch.batch_size[0] % mini_batch_size == 0``
+            mini_batch_size (int): mini-batch size when iterating the dataset. We require that ``batch.batch_size[0] % mini_batch_size == 0``.
             epochs (int): number of epochs when iterating the dataset.
-            dataloader_kwargs: internally, it returns a DataLoader over the batch.
-                The dataloader_kwargs is the kwargs passed to the DataLoader
+            dataloader_kwargs (Any): internally, it returns a DataLoader over the batch. The dataloader_kwargs is the kwargs passed to the DataLoader.
 
         Returns:
-            Iterator: an iterator that yields a mini-batch data at a time. The total number of iteration steps is
-            ``self.batch.batch_size * epochs // mini_batch_size``
+            Iterator: an iterator that yields a mini-batch data at a time. The total number of iteration steps is ``self.batch.batch_size * epochs // mini_batch_size``
         """
         assert self.batch.batch_size[0] % mini_batch_size == 0, f"{self.batch.batch_size[0]} % {mini_batch_size} != 0"
         # we can directly create a dataloader from TensorDict
@@ -646,3 +754,21 @@ class DataProtoFuture:
         if self.dispatch_fn is not None:
             output = self.dispatch_fn(output)  # split in batch dim, select using dp
         return output
+
+
+from verl.utils.torch_functional import allgather_dict_tensors
+import torch.distributed
+
+
+def all_gather_data_proto(data: DataProto, process_group):
+    # Note that this is an inplace operator just like torch.distributed.all_gather
+    group_size = torch.distributed.get_world_size(group=process_group)
+    assert isinstance(data, DataProto)
+    prev_device = data.batch.device
+    data.batch = data.batch.cuda(device=torch.cuda.current_device())
+    data.batch = allgather_dict_tensors(data.batch.contiguous(), size=group_size, group=process_group, dim=0)
+    data.batch = data.batch.to(prev_device)
+    # all gather non_tensor_batch
+    all_non_tensor_batch = [None for _ in range(group_size)]
+    torch.distributed.all_gather_object(all_non_tensor_batch, data.non_tensor_batch, group=process_group)
+    data.non_tensor_batch = {k: np.concatenate([d[k] for d in all_non_tensor_batch]) for k in data.non_tensor_batch}

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -119,6 +119,10 @@ class BatchedRewardManager:
         print(f'{reward_tensor.shape=}, {reward_tensor.dtype=}')
         assert len(scores) == reward_tensor.shape[0], f'{len(scores)=} != {reward_tensor.shape[0]=}, number of scores does not match the number of data'
         for i in range(len(data)):
+
+            data_source = data_sources[i]
+            valid_response_length = valid_response_lengths[i]
+
             reward_tensor[i, valid_response_length - 1] = scores[i]
             if self.overlong_buffer_cfg.enable:
                 overlong_buffer_len = self.overlong_buffer_cfg.len
@@ -132,13 +136,15 @@ class BatchedRewardManager:
                     reward_extra_info["overlong"].append(overlong_reward < 0)
             if data[i].non_tensor_batch['data_source'] not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0
-            if already_print_data_sources[data_source] < self.num_examine:
+            if already_print_data_sources[data[i].non_tensor_batch['data_source']] < self.num_examine:
                 already_print_data_sources[data_source] += 1
                 print("[prompt]",  prompts[i])
                 print("[response]", solutions[i])
                 print("[ground_truth]", ground_truths[i])
                 print(f'[score]', reward_tensor[i, valid_prompt_length - 1])
         if return_dict:
+            print(f'Returning reward tensor with shape {reward_tensor.shape} and dtype {reward_tensor.dtype}')
+            print(f'Returning reward extra info with keys {reward_extra_info.keys()}')
             return {'reward_tensor': reward_tensor, 'reward_extra_info': reward_extra_info}
         return reward_tensor
 

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -228,7 +228,7 @@ def main_task(config, compute_score=None):
         reward_manager_cls = BatchedRewardManager
     else:
         raise NotImplementedError
-    reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=0, compute_score=compute_score, overlong_buffer_cfg=config.custem_reward_function.overlong_buffer)
+    reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=0, compute_score=compute_score, overlong_buffer_cfg=config.reward_manager.get('overlong_buffer', None))
 
     # Turn off num_examine, context length too long
     if config.trainer.get('run_validation', True):

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -111,8 +111,8 @@ class BatchedRewardManager:
             score = result['score']
             scores = score
             for key, value in result.items():
+                print(f'Adding {key} to reward_extra_info')
                 for v in value:
-                    print(f'Adding {key} to reward_extra_info')
                     reward_extra_info[key].append(v)
         else:
             scores = result
@@ -142,7 +142,9 @@ class BatchedRewardManager:
                 print("[prompt]",  prompts[i])
                 print("[response]", solutions[i])
                 print("[ground_truth]", ground_truths[i])
-                print(f'[score]', reward_tensor[i, valid_prompt_length - 1])
+                print("[pred]", reward_extra_info['pred'][i])
+                print('[score]', reward_tensor[i, valid_prompt_length - 1])
+                print("[data_source]", data_source)
         if return_dict:
             print(f'Returning reward tensor with shape {reward_tensor.shape} and dtype {reward_tensor.dtype}')
             print(f'Returning reward extra info with keys {reward_extra_info.keys()}')

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -29,6 +29,7 @@ class BatchedRewardManager:
     """
 
     def __init__(self, tokenizer, num_examine, compute_score=None, overlong_buffer_cfg=None, max_resp_length=None) -> None:
+        print(f'Initializing BatchedRewardManager with {overlong_buffer_cfg=}, {max_resp_length=}')
         self.tokenizer = tokenizer
         self.num_examine = num_examine  # the number of batches of decoded responses to print to the console
         self.compute_score = compute_score or _default_compute_score
@@ -37,6 +38,9 @@ class BatchedRewardManager:
 
         if self.overlong_buffer_cfg is not None:
             assert self.max_resp_length is not None, f'max resp length must be provided if {self.overlong_buffer_cfg=}, but got None'
+            assert self.overlong_buffer_cfg.enable in [True, False], f'{self.overlong_buffer_cfg.enable=} must be a boolean'
+            assert self.overlong_buffer_cfg.len is not None, f'{self.overlong_buffer_cfg.len=} must be provided'
+            assert self.overlong_buffer_cfg.penalty_factor is not None, f'{self.overlong_buffer_cfg.penalty_factor=} must be provided'
 
 
     def __call__(self, data: DataProto):

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -112,7 +112,7 @@ class BatchedRewardManager:
 
         if isinstance(result, dict):
             scores = result['score']
-            for k, v in scores.items():
+            for k, v in result.items():
                 reward_extra_info[k] = v
         else:
             scores = result

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -145,7 +145,8 @@ class BatchedRewardManager:
                 print("[prompt]",  prompts[i])
                 print("[response]", solutions[i])
                 print("[ground_truth]", ground_truths[i])
-                print("[pred]", reward_extra_info['pred'][i])
+                if 'pred' in reward_extra_info.keys():
+                    print("[pred]", reward_extra_info['pred'][i])
                 print('[score]', reward_tensor[i, valid_prompt_length - 1])
                 print("[data_source]", data_source)
         if return_dict:

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -141,14 +141,8 @@ def judge_compute_score(data_sources, solution_strs, ground_truths, extra_infos=
     return reward_func(solution_strs, None, prompt_metadata)
 
 def mcq_compute_score(data_sources, solution_strs, ground_truths, extra_infos=None):
-    from nemo_skills.training.openrlhf.mcq_reward import reward_func
-    prompt_metadata = []
-    for ground_truth, extra_info, in zip(ground_truths, extra_infos):
-        prompt_metadata.append({
-            "problem": extra_info['problem'],
-            "expected_answer": ground_truth,
-        })
-    return reward_func(solution_strs, None, prompt_metadata)
+    from nemo_skills.training.openrlhf.mcq_reward import reward_func_single
+    return reward_func_single(data_sources, solution_strs, ground_truths, None)
 
 @hydra.main(config_path='config', config_name='ppo_trainer', version_base=None)
 def main(config):

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -118,6 +118,9 @@ class BatchedRewardManager:
             scores = result
         print(f'{len(scores)=}, {len(data)=}, {len(data_sources)=}, {len(solutions)=}, {len(ground_truths)=}, {len(extra_infos)=}')
         print(f'{reward_tensor.shape=}, {reward_tensor.dtype=}')
+        print(f'{reward_extra_info.keys()=}')
+        for k in reward_extra_info.keys():
+            print(f'{k}: {len(reward_extra_info[k])}')
         assert len(scores) == reward_tensor.shape[0], f'{len(scores)=} != {reward_tensor.shape[0]=}, number of scores does not match the number of data'
         for i in range(len(data)):
 

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -218,7 +218,8 @@ def main_task(config, compute_score=None):
         role_worker_mapping[Role.RewardModel] = ray.remote(RewardModelWorker)
         mapping[Role.RewardModel] = global_pool_id
 
-    reward_manager_name = config.reward_model.get("reward_manager", "naive")
+    # reward_manager_name = config.reward_model.get("reward_manager", "naive")
+    reward_manager_name = config.reward_model.reward_manager.name
     if reward_manager_name == 'naive':
         from verl.workers.reward_manager import NaiveRewardManager
         reward_manager_cls = NaiveRewardManager

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -117,6 +117,7 @@ class BatchedRewardManager:
             scores = result
         print(f'{len(scores)=}, {len(data)=}, {len(data_sources)=}, {len(solutions)=}, {len(ground_truths)=}, {len(extra_infos)=}')
         print(f'{reward_tensor.shape=}, {reward_tensor.dtype=}')
+        assert len(scores) == reward_tensor.shape[0], f'{len(scores)=} != {reward_tensor.shape[0]=}, number of scores does not match the number of data'
         for i in range(len(data)):
             reward_tensor[i, valid_response_length - 1] = scores[i]
             if self.overlong_buffer_cfg.enable:

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -252,7 +252,7 @@ def main_task(config, compute_score=None):
 
     # Turn off num_examine, context length too long
     if config.trainer.get('run_validation', True):
-        val_reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=0, compute_score=compute_score, overlong_buffer_cfg=config.reward_model.reward_manager.get('overlong_buffer', None), max_response_length=config.data.max_response_length)
+        val_reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=1, compute_score=compute_score, overlong_buffer_cfg=config.reward_model.reward_manager.get('overlong_buffer', None), max_response_length=config.data.max_response_length)
     else:
         val_reward_fn = None
 

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -28,16 +28,16 @@ class BatchedRewardManager:
     """The reward manager.
     """
 
-    def __init__(self, tokenizer, num_examine, compute_score=None, overlong_buffer_cfg=None, max_resp_length=None) -> None:
-        print(f'Initializing BatchedRewardManager with {overlong_buffer_cfg=}, {max_resp_length=}')
+    def __init__(self, tokenizer, num_examine, compute_score=None, overlong_buffer_cfg=None, max_response_length=None) -> None:
+        print(f'Initializing BatchedRewardManager with {overlong_buffer_cfg=}, {max_response_length=}')
         self.tokenizer = tokenizer
         self.num_examine = num_examine  # the number of batches of decoded responses to print to the console
         self.compute_score = compute_score or _default_compute_score
         self.overlong_buffer_cfg = overlong_buffer_cfg
-        self.max_resp_length = max_resp_length
+        self.max_response_length = max_response_length
 
         if self.overlong_buffer_cfg is not None:
-            assert self.max_resp_length is not None, f'max resp length must be provided if {self.overlong_buffer_cfg=}, but got None'
+            assert self.max_response_length is not None, f'max resp length must be provided if {self.overlong_buffer_cfg=}, but got None'
             assert self.overlong_buffer_cfg.enable in [True, False], f'{self.overlong_buffer_cfg.enable=} must be a boolean'
             assert self.overlong_buffer_cfg.len is not None, f'{self.overlong_buffer_cfg.len=} must be provided'
             assert self.overlong_buffer_cfg.penalty_factor is not None, f'{self.overlong_buffer_cfg.penalty_factor=} must be provided'
@@ -108,7 +108,7 @@ class BatchedRewardManager:
             reward_tensor[i, valid_response_length - 1] = scores[i]
             if self.overlong_buffer_cfg.enable:
                 overlong_buffer_len = self.overlong_buffer_cfg.len
-                expected_len = self.max_resp_len - overlong_buffer_len
+                expected_len = self.max_response_length - overlong_buffer_len
                 exceeded_len = valid_response_length - expected_len
                 overlong_penalty_factor = self.overlong_buffer_cfg.penalty_factor
                 overlong_reward = min(-exceeded_len / overlong_buffer_len * overlong_penalty_factor, 0)
@@ -234,11 +234,11 @@ def main_task(config, compute_score=None):
         reward_manager_cls = BatchedRewardManager
     else:
         raise NotImplementedError
-    reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=0, compute_score=compute_score, overlong_buffer_cfg=config.reward_model.reward_manager.get('overlong_buffer', None), max_resp_length=config.data.max_response_length)
+    reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=0, compute_score=compute_score, overlong_buffer_cfg=config.reward_model.reward_manager.get('overlong_buffer', None), max_response_length=config.data.max_response_length)
 
     # Turn off num_examine, context length too long
     if config.trainer.get('run_validation', True):
-        val_reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=0, compute_score=compute_score, overlong_buffer_cfg=config.reward_model.reward_manager.get('overlong_buffer', None), max_resp_length=config.data.max_response_length)
+        val_reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=0, compute_score=compute_score, overlong_buffer_cfg=config.reward_model.reward_manager.get('overlong_buffer', None), max_response_length=config.data.max_response_length)
     else:
         val_reward_fn = None
 

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -238,7 +238,7 @@ def main_task(config, compute_score=None):
 
     # Turn off num_examine, context length too long
     if config.trainer.get('run_validation', True):
-        val_reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=0, compute_score=compute_score)
+        val_reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=0, compute_score=compute_score, overlong_buffer_cfg=config.reward_model.reward_manager.get('overlong_buffer', None), max_resp_length=config.data.max_response_length)
     else:
         val_reward_fn = None
 

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -108,7 +108,7 @@ class BatchedRewardManager:
         )
         scores = []
         if isinstance(result, dict):
-            # result is a dictionary with "score", and possibly other arrays like "acc", "preds", etc.
+            # result is a dictionary with "score", and possibly other arrays like "acc", "pred", etc.
             score = result['score']
             scores = score
             for key, value in result.items():
@@ -162,8 +162,8 @@ class BatchedRewardManager:
                 print("[response]", solutions[i])
                 print("[ground_truth]", ground_truths[i])
 
-                if 'preds' in reward_extra_info.keys():
-                    print("[pred]", reward_extra_info['preds'][i])
+                if 'pred' in reward_extra_info.keys():
+                    print("[pred]", reward_extra_info['pred'][i])
 
                 print('[score]', reward_tensor[i, valid_response_length - 1])
                 print("[data_source]", data_source)

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -228,7 +228,7 @@ def main_task(config, compute_score=None):
         reward_manager_cls = BatchedRewardManager
     else:
         raise NotImplementedError
-    reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=0, compute_score=compute_score, overlong_buffer_cfg=config.reward_manager.get('overlong_buffer', None))
+    reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=0, compute_score=compute_score, overlong_buffer_cfg=config.reward_model.reward_manager.get('overlong_buffer', None))
 
     # Turn off num_examine, context length too long
     if config.trainer.get('run_validation', True):

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -109,7 +109,7 @@ class BatchedRewardManager:
         scores = []
         if isinstance(result, dict):
             score = result['score']
-            scores.append(score)
+            scores = score
             for key, value in result.items():
                 for v in value:
                     reward_extra_info[key].append(v)

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -154,7 +154,7 @@ def mcq_compute_score(data_source, solution_str, ground_truth, extra_info=None):
     from nemo_skills.training.openrlhf.mcq_reward import reward_func_single
     return reward_func_single(data_source, solution_str, ground_truth, extra_info)
 
-def mcq_compute_score_batched(data_source, solution_str, ground_truth, extra_info=None):
+def mcq_compute_score_batched(data_sources, solution_strs, ground_truths, extra_infos=None):
     from nemo_skills.training.openrlhf.mcq_reward import reward_func_batched
     return reward_func_batched(data_source, solution_str, ground_truth, extra_info)
 

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -112,6 +112,7 @@ class BatchedRewardManager:
             scores = score
             for key, value in result.items():
                 for v in value:
+                    print(f'Adding {key} to reward_extra_info')
                     reward_extra_info[key].append(v)
         else:
             scores = result

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -151,7 +151,11 @@ def judge_compute_score(data_sources, solution_strs, ground_truths, extra_infos=
     return reward_func(solution_strs, None, prompt_metadata)
 
 def mcq_compute_score(data_source, solution_str, ground_truth, extra_info=None):
-    from nemo_skills.training.openrlhf.mcq_reward import reward_func_single, reward_func_batched
+    from nemo_skills.training.openrlhf.mcq_reward import reward_func_single
+    return reward_func_single(data_source, solution_str, ground_truth, extra_info)
+
+def mcq_compute_score_batched(data_source, solution_str, ground_truth, extra_info=None):
+    from nemo_skills.training.openrlhf.mcq_reward import reward_func_batched
     return reward_func_batched(data_source, solution_str, ground_truth, extra_info)
 
 @hydra.main(config_path='config', config_name='ppo_trainer', version_base=None)
@@ -161,6 +165,8 @@ def main(config):
         compute_score_fn = judge_compute_score
     elif compute_score == 'mcq-accuracy':
         compute_score_fn = mcq_compute_score
+    elif compute_score == 'mcq-accuracy-batched':
+        compute_score_fn = mcq_compute_score_batched
     else:
         compute_score_fn = None
     run_ppo(config, compute_score_fn)

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -156,7 +156,7 @@ def mcq_compute_score(data_source, solution_str, ground_truth, extra_info=None):
 
 def mcq_compute_score_batched(data_sources, solution_strs, ground_truths, extra_infos=None):
     from nemo_skills.training.openrlhf.mcq_reward import reward_func_batched
-    return reward_func_batched(data_source, solution_str, ground_truth, extra_info)
+    return reward_func_batched(data_sources, solution_strs, ground_truths, extra_infos)
 
 @hydra.main(config_path='config', config_name='ppo_trainer', version_base=None)
 def main(config):

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -115,7 +115,8 @@ class BatchedRewardManager:
                     reward_extra_info[key].append(v)
         else:
             reward_tensor = result
-
+        print(f'{len(scores)=}, {len(data)=}, {len(data_sources)=}, {len(solutions)=}, {len(ground_truths)=}, {len(extra_infos)=}')
+        print(f'{reward_tensor.shape=}, {reward_tensor.dtype=}')
         for i in range(len(data)):
             reward_tensor[i, valid_response_length - 1] = scores[i]
             if self.overlong_buffer_cfg.enable:

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -114,7 +114,7 @@ class BatchedRewardManager:
                 for v in value:
                     reward_extra_info[key].append(v)
         else:
-            reward_tensor = result
+            scores = result
         print(f'{len(scores)=}, {len(data)=}, {len(data_sources)=}, {len(solutions)=}, {len(ground_truths)=}, {len(extra_infos)=}')
         print(f'{reward_tensor.shape=}, {reward_tensor.dtype=}')
         for i in range(len(data)):

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -121,6 +121,7 @@ class BatchedRewardManager:
         print(f'{reward_extra_info.keys()=}')
         for k in reward_extra_info.keys():
             print(f'{k}: {len(reward_extra_info[k])}')
+            print(f'Total {k}: {sum(reward_extra_info[k])}')
         assert len(scores) == reward_tensor.shape[0], f'{len(scores)=} != {reward_tensor.shape[0]=}, number of scores does not match the number of data'
         for i in range(len(data)):
 

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -109,11 +109,23 @@ def judge_compute_score(data_sources, solution_strs, ground_truths, extra_infos=
         })
     return reward_func(solution_strs, None, prompt_metadata)
 
+def mcq_compute_score(data_sources, solution_strs, ground_truths, extra_infos=None):
+    from nemo_skills.training.openrlhf.mcq_reward import reward_func
+    prompt_metadata = []
+    for ground_truth, extra_info, in zip(ground_truths, extra_infos):
+        prompt_metadata.append({
+            "problem": extra_info['problem'],
+            "expected_answer": ground_truth,
+        })
+    return reward_func(solution_strs, None, prompt_metadata)
+
 @hydra.main(config_path='config', config_name='ppo_trainer', version_base=None)
 def main(config):
     compute_score = config.reward_model.get('compute_score', None)
     if compute_score == 'math-judge':
         compute_score_fn = judge_compute_score
+    elif compute_score == 'mcq-accuracy':
+        compute_score_fn = mcq_compute_score
     else:
         compute_score_fn = None
     run_ppo(config, compute_score_fn)

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -242,11 +242,11 @@ def main_task(config, compute_score=None):
         reward_manager_cls = BatchedRewardManager
     else:
         raise NotImplementedError
-    reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=0, compute_score=compute_score, overlong_buffer_cfg=config.reward_model.reward_manager.get('overlong_buffer', None), max_response_length=config.data.max_response_length)
+    reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=2, compute_score=compute_score, overlong_buffer_cfg=config.reward_model.reward_manager.get('overlong_buffer', None), max_response_length=config.data.max_response_length)
 
     # Turn off num_examine, context length too long
     if config.trainer.get('run_validation', True):
-        val_reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=1, compute_score=compute_score, overlong_buffer_cfg=config.reward_model.reward_manager.get('overlong_buffer', None), max_response_length=config.data.max_response_length)
+        val_reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=2, compute_score=compute_score, overlong_buffer_cfg=config.reward_model.reward_manager.get('overlong_buffer', None), max_response_length=config.data.max_response_length)
     else:
         val_reward_fn = None
 

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -140,9 +140,9 @@ def judge_compute_score(data_sources, solution_strs, ground_truths, extra_infos=
         })
     return reward_func(solution_strs, None, prompt_metadata)
 
-def mcq_compute_score(data_sources, solution_strs, ground_truths, extra_infos=None):
+def mcq_compute_score(data_source, solution_str, ground_truth, extra_info=None):
     from nemo_skills.training.openrlhf.mcq_reward import reward_func_single
-    return reward_func_single(data_sources, solution_strs, ground_truths, None)
+    return reward_func_single(data_source, solution_str, ground_truth, extra_info)
 
 @hydra.main(config_path='config', config_name='ppo_trainer', version_base=None)
 def main(config):

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -121,7 +121,8 @@ class BatchedRewardManager:
         print(f'{reward_extra_info.keys()=}')
         for k in reward_extra_info.keys():
             print(f'{k}: {len(reward_extra_info[k])}')
-            print(f'Total {k}: {sum(reward_extra_info[k])}')
+            if len(reward_extra_info[k]) > 0 and isinstance(reward_extra_info[k][0], int):
+                print(f'Total {k}: {sum(reward_extra_info[k])}')
         assert len(scores) == reward_tensor.shape[0], f'{len(scores)=} != {reward_tensor.shape[0]=}, number of scores does not match the number of data'
         for i in range(len(data)):
 
@@ -148,7 +149,7 @@ class BatchedRewardManager:
                 print("[ground_truth]", ground_truths[i])
                 if 'pred' in reward_extra_info.keys():
                     print("[pred]", reward_extra_info['pred'][i])
-                print('[score]', reward_tensor[i, valid_prompt_length - 1])
+                print('[score]', reward_tensor[i, valid_response_length - 1])
                 print("[data_source]", data_source)
         if return_dict:
             print(f'Returning reward tensor with shape {reward_tensor.shape} and dtype {reward_tensor.dtype}')

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -340,10 +340,8 @@ def compute_policy_loss(old_log_prob, log_prob, advantages, eos_mask, cliprange,
 
     pg_losses = -advantages * ratio
     if cliprange_low is not None and cliprange_high is not None:
-        print('Using DAPO') # TODO: remove this print statement
         pg_losses2 = -advantages * torch.clamp(ratio, 1.0 - cliprange_low, 1.0 + cliprange_high)
     else:
-        print('Using PPO') # TODO: remove this print statement
         pg_losses2 = -advantages * torch.clamp(ratio, 1.0 - cliprange, 1.0 + cliprange)
 
     pg_loss = verl_F.masked_mean(torch.max(pg_losses, pg_losses2), eos_mask)

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -306,7 +306,7 @@ def get_policy_probability(old_log_prob, log_prob):
     return pg_losses
 
 
-def compute_policy_loss(old_log_prob, log_prob, advantages, eos_mask, cliprange):
+def compute_policy_loss(old_log_prob, log_prob, advantages, eos_mask, cliprange, cliprange_low=None, cliprange_high=None):
     """Adapted from https://github.com/huggingface/trl/blob/main/trl/trainer/ppo_trainer.py#L1122
 
     Args:
@@ -320,6 +320,12 @@ def compute_policy_loss(old_log_prob, log_prob, advantages, eos_mask, cliprange)
             shape: (bs, response_length)
         cliprange: (float)
             The clip range used in PPO. See https://arxiv.org/abs/1707.06347
+        cliprange_low: (float)
+            The lower bound of the clip range used in DAPO.
+            Will have higher priority than cliprange if specified.
+        cliprange_high: (float)
+            The upper bound of the clip range used in DAPO.
+            Will have higher priority than cliprange if specified.
 
     Returns:
         pg_loss: `a scalar torch.Tensor`
@@ -333,7 +339,12 @@ def compute_policy_loss(old_log_prob, log_prob, advantages, eos_mask, cliprange)
     ppo_kl = verl_F.masked_mean(-negative_approx_kl, eos_mask)
 
     pg_losses = -advantages * ratio
-    pg_losses2 = -advantages * torch.clamp(ratio, 1.0 - cliprange, 1.0 + cliprange)
+    if cliprange_low is not None and cliprange_high is not None:
+        print('Using DAPO') # TODO: remove this print statement
+        pg_losses2 = -advantages * torch.clamp(ratio, 1.0 - cliprange_low, 1.0 + cliprange_high)
+    else:
+        print('Using PPO') # TODO: remove this print statement
+        pg_losses2 = -advantages * torch.clamp(ratio, 1.0 - cliprange, 1.0 + cliprange)
 
     pg_loss = verl_F.masked_mean(torch.max(pg_losses, pg_losses2), eos_mask)
     pg_clipfrac = verl_F.masked_mean(torch.gt(pg_losses2, pg_losses).float(), eos_mask)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -22,9 +22,12 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
 from pprint import pprint
-from typing import Type, Dict
+from typing import Any, Callable, Type, Dict
 from copy import deepcopy
+from collections import defaultdict
+from functools import partial
 
+import ray
 import numpy as np
 from codetiming import Timer
 from omegaconf import OmegaConf, open_dict
@@ -91,11 +94,43 @@ class ResourcePoolManager:
                                             name_prefix=resource_pool_name)
             self.resource_pool_dict[resource_pool_name] = resource_pool
 
+        self._check_resource_available()
+
     def get_resource_pool(self, role: Role) -> RayResourcePool:
         """Get the resource pool of the worker_cls"""
         return self.resource_pool_dict[self.mapping[role]]
 
+    def get_n_gpus(self) -> int:
+        """Get the number of gpus in this cluster."""
+        return sum([n_gpus for process_on_nodes in self.resource_pool_spec.values() for n_gpus in process_on_nodes])
 
+    def _check_resource_available(self):
+        """Check if the resource pool can be satisfied in this ray cluster."""
+        node_available_resources = ray.state.available_resources_per_node()
+        node_available_gpus = {node: node_info.get('GPU', 0) for node, node_info in node_available_resources.items()}
+
+        # check total required gpus can be satisfied
+        total_available_gpus = sum(node_available_gpus.values())
+        total_required_gpus = sum(
+            [n_gpus for process_on_nodes in self.resource_pool_spec.values() for n_gpus in process_on_nodes])
+        if total_available_gpus < total_required_gpus:
+            raise ValueError(
+                f"Total available GPUs {total_available_gpus} is less than total desired GPUs {total_required_gpus}")
+
+        # check each resource pool can be satisfied, O(#resource_pools * #nodes)
+        for resource_pool_name, process_on_nodes in self.resource_pool_spec.items():
+            num_gpus, num_nodes = process_on_nodes[0], len(process_on_nodes)
+            for node, available_gpus in node_available_gpus.items():
+                if available_gpus >= num_gpus:
+                    node_available_gpus[node] -= num_gpus
+                    num_nodes -= 1
+                    if num_nodes == 0:
+                        break
+            if num_nodes > 0:
+                raise ValueError(
+                    f"Resource pool {resource_pool_name}: {num_gpus}*{num_nodes} cannot be satisfied in this ray cluster"
+                )
+    
 import torch
 from verl.utils.torch_functional import masked_mean
 
@@ -209,6 +244,37 @@ def reduce_metrics(metrics: dict):
     for key, val in metrics.items():
         metrics[key] = np.mean(val)
     return metrics
+
+
+def calc_maj_val(data: list[dict[str, Any]], vote_key: str, val_key: str) -> float:
+    """
+    Calculate the majority voting metric
+    """
+    vote2vals = defaultdict(list)
+    for d in data:
+        vote2vals[d[vote_key]].append(d[val_key])
+
+    vote2cnt = {k: len(v) for k, v in vote2vals.items()}
+    maj_vote = max(vote2cnt, key=vote2cnt.get)
+
+    maj_val = vote2vals[maj_vote][0]
+
+    return maj_val
+
+def bootstrap_metric(data: list[dict[str, Any]],
+                     subset_size: int,
+                     reduce_fns: list[Callable[[np.ndarray], float]],
+                     n_bootstrap: int = 1000,
+                     seed: int = 42) -> list[tuple[float, float]]:
+    np.random.seed(seed)
+
+    bootstrap_metric_lsts = [[] for _ in range(len(reduce_fns))]
+    for _ in range(n_bootstrap):
+        bootstrap_idxs = np.random.choice(len(data), size=subset_size, replace=True)
+        bootstrap_data = [data[i] for i in bootstrap_idxs]
+        for i, reduce_fn in enumerate(reduce_fns):
+            bootstrap_metric_lsts[i].append(reduce_fn(bootstrap_data))
+    return [(np.mean(lst), np.std(lst)) for lst in bootstrap_metric_lsts]
 
 
 def _compute_response_info(batch):
@@ -358,7 +424,7 @@ def compute_timing_metrics(batch, timing_raw):
 def _timer(name: str, timing_raw: Dict[str, float]):
     with Timer(name=name, logger=None) as timer:
         yield
-    timing_raw[name] = timer.last
+    timing_raw[name] += timer.last  # Allow to accumulate time
 
 
 class RayPPOTrainer(object):
@@ -439,6 +505,23 @@ class RayPPOTrainer(object):
         # number of GPUs total
         n_gpus = config.trainer.n_gpus_per_node * config.trainer.nnodes
 
+        filter_cfg = config.algorithm.filter_groups
+        if filter_cfg.enable:
+            assert filter_cfg.max_num_gen_batches > 0, f"{filter_cfg.max_num_gen_batches=}"
+            assert filter_cfg.metric is not None, f"{filter_cfg.metric=}"
+        else:
+            assert config.data.train_batch_size == config.data.gen_batch_size, \
+                f"train_batch_size must be equal to gen_batch_size when filter_groups.enable is False, but got {config.data.train_batch_size =} and {config.data.gen_batch_size =}"
+
+        overlong_buffer_cfg = config.custom_reward_function.overlong_buffer
+        if overlong_buffer_cfg.enable:
+            assert config.data.max_response_length >= overlong_buffer_cfg.len > 0, \
+                f"{config.data.max_response_length=} / {overlong_buffer_cfg.len=}"
+        else:
+            assert overlong_buffer_cfg.len <= 0, f"{overlong_buffer_cfg.len=} > 0 but {overlong_buffer_cfg.enable=}"
+            assert overlong_buffer_cfg.penalty_factor <= 0, f"{overlong_buffer_cfg.penalty_factor=} > 0 but {overlong_buffer_cfg.enable=}"
+            assert overlong_buffer_cfg.log == False, f"{overlong_buffer_cfg.log=} == True but {overlong_buffer_cfg.enable=}"
+
         # 1. Check total batch size for data correctness
         real_train_batch_size = config.data.train_batch_size * config.actor_rollout_ref.rollout.n
         assert real_train_batch_size % n_gpus == 0, \
@@ -483,10 +566,12 @@ class RayPPOTrainer(object):
                                      "reward_model")
 
         # Actor
+        # check if train_batch_size is larger than ppo_mini_batch_size
         # if NOT dynamic_bsz, we must ensure:
         #    ppo_mini_batch_size is divisible by ppo_micro_batch_size
         #    ppo_micro_batch_size * sequence_parallel_size >= n_gpus
         if not config.actor_rollout_ref.actor.use_dynamic_bsz:
+            assert config.data.train_batch_size >= config.actor_rollout_ref.actor.ppo_mini_batch_size
             sp_size = config.actor_rollout_ref.actor.get('ulysses_sequence_parallel_size', 1)
             if config.actor_rollout_ref.actor.ppo_micro_batch_size is not None:
                 assert config.actor_rollout_ref.actor.ppo_mini_batch_size % config.actor_rollout_ref.actor.ppo_micro_batch_size == 0
@@ -494,6 +579,7 @@ class RayPPOTrainer(object):
 
         # critic
         if self.use_critic and not config.critic.use_dynamic_bsz:
+            assert config.data.train_batch_size >= config.critic.ppo_mini_batch_size
             sp_size = config.critic.get('ulysses_sequence_parallel_size', 1)
             if config.critic.ppo_micro_batch_size is not None:
                 assert config.critic.ppo_mini_batch_size % config.critic.ppo_micro_batch_size == 0
@@ -536,13 +622,13 @@ class RayPPOTrainer(object):
             sampler = SequentialSampler(data_source=self.train_dataset)
 
         self.train_dataloader = StatefulDataLoader(dataset=self.train_dataset,
-                                                   batch_size=self.config.data.train_batch_size,
+                                                   batch_size=self.config.data.gen_batch_size,
                                                    drop_last=True,
                                                    collate_fn=collate_fn,
                                                    sampler=sampler)
 
         assert len(self.train_dataloader) >= 1
-
+        
         if self.val_reward_fn is not None:
             self.val_dataset = RLHFDataset(parquet_files=self.config.data.val_files,
                                         tokenizer=self.tokenizer,
@@ -660,9 +746,8 @@ class RayPPOTrainer(object):
         self.validation_table = new_table
 
     def _validate(self):
-        reward_tensor_lst = []
         data_source_lst = []
-        data_uid_lst = []
+        reward_extra_infos_dict: dict[str, list] = defaultdict(list)
 
         # Lists to collect samples for the table
         sample_inputs = []
@@ -694,12 +779,14 @@ class RayPPOTrainer(object):
                 'do_sample': True if self.config.actor_rollout_ref.rollout.n_val > 1 else False,
                 'validate': True,
             }
+            print(f'test_gen_batch meta info: {test_gen_batch.meta_info}')
 
             # pad to be divisible by dp_size
             test_gen_batch_padded, pad_size = pad_dataproto_to_divisor(test_gen_batch, self.actor_rollout_wg.world_size)
             test_output_gen_batch_padded = self.actor_rollout_wg.generate_sequences(test_gen_batch_padded)
             # unpad
-            test_output_gen_batch = unpad_dataproto(test_output_gen_batch_padded, pad_size=pad_size*self.config.actor_rollout_ref.rollout.n_val)
+            test_output_gen_batch = unpad_dataproto(test_output_gen_batch_padded, pad_size=pad_size)
+            print('validation generation end')
 
             # Store generated outputs
             output_ids = test_output_gen_batch.batch['responses']
@@ -710,57 +797,87 @@ class RayPPOTrainer(object):
             test_batch = test_batch.union(test_output_gen_batch)
 
             # evaluate using reward_function
-            reward_tensor = self.val_reward_fn(test_batch)
+            result = self.val_reward_fn(test_batch, return_dict=True)
+            reward_tensor = result["reward_tensor"]
+            if "reward_extra_info" in result:
+                for key, lst in result["reward_extra_info"].items():
+                    reward_extra_infos_dict[key].extend(lst)
 
             # Store scores
             scores = reward_tensor.sum(-1).cpu().tolist()
             sample_scores.extend(scores)
 
-            reward_tensor_lst.append(reward_tensor)
-            data_source = test_batch.non_tensor_batch.get('data_source', ['unknown'] * reward_tensor.shape[0])
-            for idx, x in enumerate(test_batch.non_tensor_batch['extra_info']):
-                if 'name' in x:
-                    data_source[idx] = x['name']
-            data_source_lst.append(data_source)
-            data_uid_lst.append(test_batch.non_tensor_batch['uid'])
+            data_source_lst.append(test_batch.non_tensor_batch.get('data_source', ['unknown'] * reward_tensor.shape[0]))
 
         self._maybe_log_val_generations_to_wandb(inputs=sample_inputs, outputs=sample_outputs, scores=sample_scores)
 
-        reward_tensor = torch.cat(reward_tensor_lst, dim=0).sum(-1).cpu()  # (batch_size,)
-        data_sources = np.concatenate(data_source_lst, axis=0)
-        data_uids = np.concatenate(data_uid_lst, axis=0)
+        for lst in reward_extra_infos_dict.values():
+            assert len(lst) == 0 or len(lst) == len(sample_scores)
 
-        # evaluate test_score based on data source
-        data_source_reward = {}
-        for i in range(reward_tensor.shape[0]):
-            data_source = data_sources[i]
-            data_uid = data_uids[i]
-            if data_source not in data_source_reward:
-                data_source_reward[data_source] = {}
-            if data_uid not in data_source_reward[data_source]:
-                data_source_reward[data_source][data_uid] = []
-            data_source_reward[data_source][data_uid].append(reward_tensor[i].item())
+        data_sources = np.concatenate(data_source_lst, axis=0)
+
+        data_src2prompt2var2vals = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+        for sample_idx, data_source in enumerate(data_sources):
+            prompt = sample_inputs[sample_idx]
+
+            var2vals = data_src2prompt2var2vals[data_source][prompt]
+            var2vals["final_reward"].append(sample_scores[sample_idx])
+            for metric_name, metric_vals in reward_extra_infos_dict.items():
+                var2vals[metric_name].append(metric_vals[sample_idx])
+
+        data_src2prompt2var2metric = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
+        for data_source, prompt2var2vals in data_src2prompt2var2vals.items():
+            for prompt, var2vals in prompt2var2vals.items():
+                n_resps = len(var2vals["final_reward"])
+                preds = var2vals["pred"]
+                for var_name, var_vals in var2vals.items():
+                    if var_name in ["pred", "final_reward"]:
+                        continue
+                    metric = {}
+
+                    metric[f"mean@{n_resps}"] = np.mean(var_vals)
+                    metric[f"std@{n_resps}"] = np.std(var_vals)
+
+                    ns = []
+                    n = 2
+                    while n < n_resps:
+                        ns.append(n)
+                        n *= 2
+                    ns.append(n_resps)
+
+                    data = [{"val": val, "pred": pred} for val, pred in zip(var_vals, preds)]
+                    for n in ns:
+
+                        (bon_mean, bon_std), (won_mean, won_std), (maj_n_mean, maj_n_std) = bootstrap_metric(
+                            data,
+                            subset_size=n,
+                            reduce_fns=[
+                                lambda arr: np.max([d["val"] for d in arr]),
+                                lambda arr: np.min([d["val"] for d in arr]),
+                                partial(calc_maj_val, vote_key="pred", val_key="val")
+                            ])
+                        metric[f"best@{n}/mean"], metric[f"best@{n}/std"] = bon_mean, bon_std
+                        metric[f"worst@{n}/mean"], metric[f"worst@{n}/std"] = won_mean, won_std
+                        metric[f"maj@{n}/mean"], metric[f"maj@{n}/std"] = maj_n_mean, maj_n_std
+
+                    data_src2prompt2var2metric[data_source][prompt][var_name] = metric
+
+        data_src2var2metric2prompt_vals = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+        for data_source, prompt2var2metric in data_src2prompt2var2metric.items():
+            for prompt, var2metric in prompt2var2metric.items():
+                for var_name, metric in var2metric.items():
+                    for metric_name, metric_val in metric.items():
+                        data_src2var2metric2prompt_vals[data_source][var_name][metric_name].append(metric_val)
 
         metric_dict = {}
-        stacked_rewards = []
-        for data_source, rewards in data_source_reward.items():
-            # shape (bs, n)
-            rewards = np.array(list(rewards.values()))
-            stacked_rewards.append(rewards)
-            # Here we assume reward model generates binary 0/1 rewards
-            metric_dict[f'val/test_score/{data_source}/pass@1'] = np.mean(rewards)
-            metric_dict[f'val/test_score/{data_source}/pass@1/std'] = np.mean(rewards.std(axis=1))
-            metric_dict[f'val/test_score/{data_source}/pass@{self.config.actor_rollout_ref.rollout.n_val}'] = np.mean(
-                rewards.max(axis=1))
+        for data_source, var2metric2prompt_vals in data_src2var2metric2prompt_vals.items():
+            for var_name, metric2prompt_vals in var2metric2prompt_vals.items():
+                for metric_name, prompt_vals in metric2prompt_vals.items():
+                    pfx = f"{data_source}/{var_name}/{metric_name}"
+                    metric_dict[pfx] = np.mean(prompt_vals)
 
-        if len(list(data_source_reward.keys())) > 1:
-            stacked_rewards = np.concatenate(stacked_rewards, axis=0)
-            metric_dict[f'val/test_score/all/pass@1'] = np.mean(stacked_rewards)
-            metric_dict[f'val/test_score/all/pass@1/std'] = np.mean(stacked_rewards.std(axis=1))
-            metric_dict[f'val/test_score/all/pass@{self.config.actor_rollout_ref.rollout.n_val}'] = np.mean(
-                stacked_rewards.max(axis=1))
-
-        return metric_dict
+        val_metric_dict = {f"val/{key}": value for key, value in metric_dict.items()}
+        return val_metric_dict
 
     def init_workers(self):
         """Init resource pool and worker group"""
@@ -871,7 +988,7 @@ class RayPPOTrainer(object):
 
         # load from hdfs
         if self.config.trainer.default_hdfs_dir is not None:
-            NotImplementedError('load from hdfs is not implemented yet')
+            raise NotImplementedError('load from hdfs is not implemented yet')
         else:
             checkpoint_folder = self.config.trainer.default_local_dir  # TODO: check path
             if not os.path.isabs(checkpoint_folder):
@@ -965,17 +1082,31 @@ class RayPPOTrainer(object):
 
         # we start from step 1
         self.global_steps += 1
+        last_val_metrics = None
 
-        self.timeout.start_iterations()
+        timing_raw = defaultdict(float)
+        batch = None
+        num_prompt_in_batch = 0
+        num_gen_batches = 0
         for epoch in range(self.config.trainer.total_epochs):
             for batch_dict in self.train_dataloader:
                 metrics = {}
-                timing_raw = {}
 
-                batch: DataProto = DataProto.from_single_dict(batch_dict)
-
+                new_batch: DataProto = DataProto.from_single_dict(batch_dict)
+                num_gen_batches += 1
                 # pop those keys for generation
-                gen_batch = batch.pop(batch_keys=['input_ids', 'attention_mask', 'position_ids'])
+                if 'multi_modal_inputs' in new_batch.non_tensor_batch.keys():
+                    gen_batch = new_batch.pop(
+                        batch_keys=['input_ids', 'attention_mask', 'position_ids'],
+                        non_tensor_batch_keys=['raw_prompt_ids', 'multi_modal_data', 'multi_modal_inputs'],
+                    )
+                else:
+                    gen_batch = new_batch.pop(
+                        batch_keys=['input_ids', 'attention_mask', 'position_ids'],
+                        non_tensor_batch_keys=['raw_prompt_ids'],
+                    )
+
+                is_last_step = self.global_steps >= self.total_training_steps
 
                 with _timer('step', timing_raw):
                     # generate a batch
@@ -1038,42 +1169,125 @@ class RayPPOTrainer(object):
                             gen_baseline_batch.meta_info['do_sample'] = False
                             gen_baseline_output = self.actor_rollout_wg.generate_sequences(gen_baseline_batch)
 
-                            batch = batch.union(gen_baseline_output)
-                            reward_baseline_tensor = self.reward_fn(batch)
+                            new_batch = new_batch.union(gen_baseline_output)
+                            reward_baseline_tensor = self.reward_fn(new_batch)
                             reward_baseline_tensor = reward_baseline_tensor.sum(dim=-1)
 
-                            batch.pop(batch_keys=list(gen_baseline_output.batch.keys()))
+                            new_batch.pop(batch_keys=list(gen_baseline_output.batch.keys()))
 
-                            batch.batch['reward_baselines'] = reward_baseline_tensor
+                            new_batch.batch['reward_baselines'] = reward_baseline_tensor
 
                             del gen_baseline_batch, gen_baseline_output
 
-                    batch.non_tensor_batch['uid'] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))],
-                                                             dtype=object)
+                    new_batch.non_tensor_batch['uid'] = np.array(
+                        [str(uuid.uuid4()) for _ in range(len(new_batch.batch))], dtype=object)
                     # repeat to align with repeated responses in rollout
-                    batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
-                    batch = batch.union(gen_batch_output)
-                    batch.non_tensor_batch['sample_uid'] = np.array(
-                        [str(uuid.uuid4()) for _ in range(len(batch.batch))],
-                        dtype=object)
+                    new_batch = new_batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
+                    new_batch = new_batch.union(gen_batch_output)
+
+                    with _timer('reward', timing_raw):
+                        # compute scores. Support both model and function-based.
+                        # We first compute the scores using reward model. Then, we call reward_fn to combine
+                        # the results from reward model and rule-based results.
+                        if self.use_rm:
+                            # we first compute reward model score
+                            reward_tensor = self.rm_wg.compute_rm_score(new_batch)
+                            new_batch = new_batch.union(reward_tensor)
+
+                        # we combine with rule-based rm
+                        reward_extra_infos_dict: dict[str, list]
+                        try:
+                            reward_result = self.reward_fn(new_batch, return_dict=True)
+                            reward_tensor = reward_result['reward_tensor']
+                            reward_extra_infos_dict = reward_result['reward_extra_info']
+                        except Exception as e:
+                            print(f'Error in reward_fn: {e}')
+                            reward_tensor = self.reward_fn(new_batch)
+                            reward_extra_infos_dict = {}
+
+                        new_batch.batch['token_level_scores'] = reward_tensor
+
+                        print(f'{list(reward_extra_infos_dict.keys())=}')
+                        if reward_extra_infos_dict:
+                            new_batch.non_tensor_batch.update({
+                                k: np.array(v) for k, v in reward_extra_infos_dict.items()
+                            })
+
+                        # compute rewards. apply_kl_penalty if available
+                        if not self.config.actor_rollout_ref.actor.get('use_kl_loss', False):
+                            new_batch, kl_metrics = apply_kl_penalty(new_batch,
+                                                                     kl_ctrl=self.kl_ctrl,
+                                                                     kl_penalty=self.config.algorithm.kl_penalty)
+                            metrics.update(
+                                kl_metrics)  # TODO: This will be cleared if we use multiple genenration batches
+                        else:
+                            new_batch.batch['token_level_rewards'] = new_batch.batch['token_level_scores']
+
+                    if not self.config.algorithm.filter_groups.enable:
+                        batch = new_batch
+                    else:  # NOTE: When prompts after filtering is less than train batch size, we skip to the next generation batch
+                        metric_name = self.config.algorithm.filter_groups.metric
+                        if metric_name == "seq_final_reward":
+                            # Turn to numpy for easier filtering
+                            new_batch.non_tensor_batch["seq_final_reward"] = new_batch.batch['token_level_scores'].sum(
+                                dim=-1).numpy()
+                        elif metric_name == "seq_reward":
+                            new_batch.non_tensor_batch["seq_reward"] = new_batch.batch['token_level_scores'].sum(
+                                dim=-1).numpy()
+
+                        # Collect the sequence reward for each trajectory
+                        prompt_uid2metric_vals = defaultdict(list)
+                        for uid, metric_val in zip(new_batch.non_tensor_batch['uid'],
+                                                   new_batch.non_tensor_batch[metric_name]):
+                            prompt_uid2metric_vals[uid].append(metric_val)
+
+                        prompt_uid2metric_std = {}
+                        for prompt_uid, metric_vals in prompt_uid2metric_vals.items():
+                            prompt_uid2metric_std[prompt_uid] = np.std(metric_vals)
+
+                        kept_prompt_uids = [uid for uid, std in prompt_uid2metric_std.items() if std > 0]
+                        num_prompt_in_batch += len(kept_prompt_uids)
+
+                        kept_traj_idxs = []
+                        for idx, traj_from_prompt_uid in enumerate(new_batch.non_tensor_batch['uid']):
+                            if traj_from_prompt_uid in kept_prompt_uids:
+                                kept_traj_idxs.append(idx)
+
+                        new_batch = new_batch[kept_traj_idxs]
+                        if batch is None:
+                            batch = new_batch
+                        else:
+                            batch = DataProto.concat([batch, new_batch])
+
+                        prompt_bsz = self.config.data.train_batch_size
+                        if num_prompt_in_batch < prompt_bsz:
+                            print(f'{num_prompt_in_batch=} < {prompt_bsz=}')
+                            max_num_gen_batches = self.config.algorithm.filter_groups.max_num_gen_batches
+                            if max_num_gen_batches <= 0 or num_gen_batches < max_num_gen_batches:
+                                print(f'{num_gen_batches=}. Keep generating...')
+                                continue
+                            else:
+                                raise ValueError(
+                                    f'{num_gen_batches=} >= {max_num_gen_batches=}. Generated too many. Please check your data.'
+                                )
+                        else:
+                            # Align the batch
+                            traj_bsz = self.config.data.train_batch_size * self.config.actor_rollout_ref.rollout.n
+                            batch = batch[:traj_bsz]
 
                     # balance the number of valid tokens on each dp rank.
                     # Note that this breaks the order of data inside the batch.
                     # Please take care when you implement group based adv computation such as GRPO and rloo
-                    self._balance_batch(batch, metrics=metrics)
+                    if self.config.trainer.balance_batch:
+                        self._balance_batch(batch, metrics=metrics)
 
                     # compute global_valid tokens
                     batch.meta_info['global_token_num'] = torch.sum(batch.batch['attention_mask'], dim=-1).tolist()
 
                     # recompute old_log_probs
-                    if self.config.data.train_batch_size == self.config.actor_rollout_ref.actor.ppo_mini_batch_size:
-                        batch.meta_info['old_log_probs_compute'] = False
-                        batch.meta_info['temperature'] = self.config.actor_rollout_ref.rollout.temperature
-                    else:
-                        batch.meta_info['old_log_probs_compute'] = True
-                        with _timer('old_log_prob', timing_raw):
-                            old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
-                            batch = batch.union(old_log_prob)
+                    with _timer('old_log_prob', timing_raw):
+                        old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
+                        batch = batch.union(old_log_prob)
 
                     if self.use_reference_policy:
                         # compute reference log_prob
@@ -1088,27 +1302,6 @@ class RayPPOTrainer(object):
                             batch = batch.union(values)
 
                     with _timer('adv', timing_raw):
-                        # compute scores. Support both model and function-based.
-                        # We first compute the scores using reward model. Then, we call reward_fn to combine
-                        # the results from reward model and rule-based results.
-                        if self.use_rm:
-                            # we first compute reward model score
-                            reward_tensor = self.rm_wg.compute_rm_score(batch)
-                            batch = batch.union(reward_tensor)
-
-                        # we combine with rule-based rm
-                        reward_tensor = self.reward_fn(batch)
-                        batch.batch['token_level_scores'] = reward_tensor
-
-                        # compute rewards. apply_kl_penalty if available
-                        if not self.config.actor_rollout_ref.actor.get('use_kl_loss', False):
-                            batch, kl_metrics = apply_kl_penalty(batch,
-                                                                 kl_ctrl=self.kl_ctrl,
-                                                                 kl_penalty=self.config.algorithm.kl_penalty)
-                            metrics.update(kl_metrics)
-                        else:
-                            batch.batch['token_level_rewards'] = batch.batch['token_level_scores']
-
                         # compute advantages, executed on the driver process
                         batch = compute_advantage(batch,
                                                   adv_estimator=self.config.algorithm.adv_estimator,
@@ -1116,13 +1309,13 @@ class RayPPOTrainer(object):
                                                   lam=self.config.algorithm.lam,
                                                   num_repeat=self.config.actor_rollout_ref.rollout.n,
                                                   normalize=self.config.algorithm.normalize_advantage)
-                                                            # Get total reward per sample
                     total_rewards = batch.batch['token_level_rewards'].sum(-1).cpu().tolist()
                     self._maybe_log_train_generations_to_wandb(
-                            inputs=input_texts,
-                            outputs=output_texts,
-                            rewards=total_rewards
-                        )
+                        inputs=input_texts, 
+                        outputs=output_texts, 
+                        rewards=total_rewards
+                    )
+
                     # update critic
                     if self.use_critic:
                         with _timer('update_critic', timing_raw):
@@ -1140,39 +1333,33 @@ class RayPPOTrainer(object):
 
                     # validate
                     if self.val_reward_fn is not None and self.config.trainer.test_freq > 0 and \
-                        self.global_steps % self.config.trainer.test_freq == 0:
+                        (is_last_step or  self.global_steps % self.config.trainer.test_freq == 0):
                         with _timer('testing', timing_raw):
                             val_metrics: dict = self._validate()
-                        pprint(f'Step {self.global_steps} validation metrics: {val_metrics}')
+                            if is_last_step:
+                                last_val_metrics = val_metrics
                         metrics.update(val_metrics)
 
-                    self.timeout.mark_iteration()
-                    if self.config.trainer.save_freq > 0 and \
-                            self.global_steps % self.config.trainer.save_freq == 0:
-                        with _timer('save_checkpoint', timing_raw):
-                            self._save_checkpoint()
-                    elif self.timeout.check_save():
+                    if self.config.trainer.save_freq > 0 and ( is_last_step or \
+                            self.global_steps % self.config.trainer.save_freq == 0):
                         with _timer('save_checkpoint', timing_raw):
                             self._save_checkpoint()
 
                 # collect metrics
                 metrics.update(compute_data_metrics(batch=batch, use_critic=self.use_critic))
                 metrics.update(compute_timing_metrics(batch=batch, timing_raw=timing_raw))
+                timing_raw = defaultdict(float)  # clear timing
+
+                metrics["train/num_gen_batches"] = num_gen_batches
+                batch = None
+                num_prompt_in_batch = 0
+                num_gen_batches = 0
 
                 # TODO: make a canonical logger that supports various backend
                 logger.log(data=metrics, step=self.global_steps)
 
-                self.global_steps += 1
-
-                if self.global_steps >= self.total_training_steps or self.timeout.last_saved:
-
-                    # perform validation after training
-                    if self.val_reward_fn is not None:
-                        val_metrics = self._validate()
-                        pprint(f'Final validation metrics: {val_metrics}')
-                        logger.log(data=val_metrics, step=self.global_steps)
-                    if self.config.trainer.save_freq > 0 and \
-                            (self.global_steps - 1) % self.config.trainer.save_freq != 0:
-                        with _timer('save_checkpoint', timing_raw):
-                            self._save_checkpoint()
+                if is_last_step:
+                    pprint(f'Final validation metrics: {last_val_metrics}')
                     return
+
+                self.global_steps += 1

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1281,8 +1281,7 @@ class RayPPOTrainer(object):
                     # balance the number of valid tokens on each dp rank.
                     # Note that this breaks the order of data inside the batch.
                     # Please take care when you implement group based adv computation such as GRPO and rloo
-                    if self.config.trainer.balance_batch:
-                        self._balance_batch(batch, metrics=metrics)
+                    self._balance_batch(batch, metrics=metrics)
 
                     # compute global_valid tokens
                     batch.meta_info['global_token_num'] = torch.sum(batch.batch['attention_mask'], dim=-1).tolist()

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -682,10 +682,8 @@ class RayPPOTrainer(object):
 
         import wandb
         columns = ["step", "input", "output", "reward"]
-        if not hasattr(self, 'training_table'):
-            self.training_table = wandb.Table(columns=columns)
-
-        new_table = wandb.Table(columns=columns, data=self.training_table.data)
+        
+        new_table = wandb.Table(columns=columns)
         inputs = inputs[:generations_to_log]
         outputs = outputs[:generations_to_log]
         rewards = rewards[:generations_to_log]
@@ -693,7 +691,6 @@ class RayPPOTrainer(object):
             new_table.add_data(self.global_steps, inp, outp, rew)
 
         wandb.log({"train/generations": new_table}, step=self.global_steps)
-        self.training_table = new_table
 
     def _maybe_log_val_generations_to_wandb(self, inputs, outputs, scores):
         """Log a table of validation samples to wandb"""

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -826,6 +826,7 @@ class RayPPOTrainer(object):
                 var2vals[metric_name].append(metric_vals[sample_idx])
 
         data_src2prompt2var2metric = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
+        print(f'Dict before metric calculation: {data_src2prompt2var2vals}')
         for data_source, prompt2var2vals in data_src2prompt2var2vals.items():
             for prompt, var2vals in prompt2var2vals.items():
                 n_resps = len(var2vals["final_reward"])

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -826,7 +826,6 @@ class RayPPOTrainer(object):
                 var2vals[metric_name].append(metric_vals[sample_idx])
 
         data_src2prompt2var2metric = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
-        print(f'Dict before metric calculation: {data_src2prompt2var2vals}')
         for data_source, prompt2var2vals in data_src2prompt2var2vals.items():
             for prompt, var2vals in prompt2var2vals.items():
                 n_resps = len(var2vals["final_reward"])

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1202,7 +1202,8 @@ class RayPPOTrainer(object):
                             reward_tensor = reward_result['reward_tensor']
                             reward_extra_infos_dict = reward_result['reward_extra_info']
                         except Exception as e:
-                            print(f'Error in reward_fn: {e}')
+                            raise e
+                            # print(f'Error in reward_fn: {e}')
                             reward_tensor = self.reward_fn(new_batch)
                             reward_extra_infos_dict = {}
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -785,7 +785,7 @@ class RayPPOTrainer(object):
             test_gen_batch_padded, pad_size = pad_dataproto_to_divisor(test_gen_batch, self.actor_rollout_wg.world_size)
             test_output_gen_batch_padded = self.actor_rollout_wg.generate_sequences(test_gen_batch_padded)
             # unpad
-            test_output_gen_batch = unpad_dataproto(test_output_gen_batch_padded, pad_size=pad_size)
+            test_output_gen_batch = unpad_dataproto(test_output_gen_batch_padded, pad_size=pad_size*self.config.actor_rollout_ref.rollout.n_val)
             print('validation generation end')
 
             # Store generated outputs

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1099,12 +1099,12 @@ class RayPPOTrainer(object):
                 if 'multi_modal_inputs' in new_batch.non_tensor_batch.keys():
                     gen_batch = new_batch.pop(
                         batch_keys=['input_ids', 'attention_mask', 'position_ids'],
-                        non_tensor_batch_keys=['raw_prompt_ids', 'multi_modal_data', 'multi_modal_inputs'],
+                        # non_tensor_batch_keys=['raw_prompt_ids', 'multi_modal_data', 'multi_modal_inputs'],
                     )
                 else:
                     gen_batch = new_batch.pop(
                         batch_keys=['input_ids', 'attention_mask', 'position_ids'],
-                        non_tensor_batch_keys=['raw_prompt_ids'],
+                        # non_tensor_batch_keys=['raw_prompt_ids'],
                     )
 
                 is_last_step = self.global_steps >= self.total_training_steps
@@ -1174,6 +1174,9 @@ class RayPPOTrainer(object):
                             reward_baseline_tensor = self.reward_fn(new_batch)
                             reward_baseline_tensor = reward_baseline_tensor.sum(dim=-1)
 
+                            # Sanity check before pop gen_baseline_output.batch.keys()
+                            for k in gen_baseline_output.batch.keys():
+                                assert k in new_batch.batch.keys(), f'{k} not in {new_batch.batch.keys()}'
                             new_batch.pop(batch_keys=list(gen_baseline_output.batch.keys()))
 
                             new_batch.batch['reward_baselines'] = reward_baseline_tensor

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -513,7 +513,7 @@ class RayPPOTrainer(object):
             assert config.data.train_batch_size == config.data.gen_batch_size, \
                 f"train_batch_size must be equal to gen_batch_size when filter_groups.enable is False, but got {config.data.train_batch_size =} and {config.data.gen_batch_size =}"
 
-        overlong_buffer_cfg = config.custom_reward_function.overlong_buffer
+        overlong_buffer_cfg = config.reward_model.reward_manager.overlong_buffer #config.custom_reward_function.overlong_buffer
         if overlong_buffer_cfg.enable:
             assert config.data.max_response_length >= overlong_buffer_cfg.len > 0, \
                 f"{config.data.max_response_length=} / {overlong_buffer_cfg.len=}"

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -258,6 +258,8 @@ class DataParallelPPOActor(BasePPOActor):
                     advantages = data['advantages']
 
                     clip_ratio = self.config.clip_ratio
+                    clip_ratio_low = self.config.get('clip_ratio_low', None)
+                    clip_ratio_high = self.config.get('clip_ratio_high', None)
                     entropy_coeff = self.config.entropy_coeff
 
                     # all return: (bsz, response_length)
@@ -282,7 +284,9 @@ class DataParallelPPOActor(BasePPOActor):
                                                                                       log_prob=log_prob,
                                                                                       advantages=advantages,
                                                                                       eos_mask=response_mask,
-                                                                                      cliprange=clip_ratio)
+                                                                                      cliprange=clip_ratio,
+                                                                                      cliprange_low=clip_ratio_low,
+                                                                                      cliprange_high=clip_ratio_high)
 
                     # compute entropy loss from entropy
                     entropy_loss = verl_F.masked_mean(entropy, response_mask)

--- a/verl/workers/actor/megatron_actor.py
+++ b/verl/workers/actor/megatron_actor.py
@@ -272,6 +272,8 @@ class MegatronPPOActor(BasePPOActor):
 
             clip_ratio = meta_info['clip_ratio']
             entropy_coeff = meta_info['entropy_coeff']
+            clip_ratio_low = meta_info.get('clip_ratio_low', None)
+            clip_ratio_high = meta_info.get('clip_ratio_high', None)
 
             # compute policy loss
             logits = output.logits
@@ -281,7 +283,9 @@ class MegatronPPOActor(BasePPOActor):
                                                                           log_prob=log_prob,
                                                                           advantages=advantages,
                                                                           eos_mask=response_mask,
-                                                                          cliprange=clip_ratio)
+                                                                          cliprange=clip_ratio,
+                                                                          cliprange_low=clip_ratio_low,
+                                                                          cliprange_high=clip_ratio_high)
             entropy_loss = vocab_parallel_compute_entropy_loss(logits, eos_mask=response_mask)
             policy_loss = pg_loss - entropy_loss * entropy_coeff
             # return loss and stats
@@ -302,7 +306,7 @@ class MegatronPPOActor(BasePPOActor):
             if forward_only:
                 meta_info = None
             else:
-                meta_info = {'clip_ratio': self.config.clip_ratio, 'entropy_coeff': self.config.entropy_coeff}
+                meta_info = {'clip_ratio': self.config.clip_ratio, 'entropy_coeff': self.config.entropy_coeff, 'clip_ratio_low': self.config.get('clip_ratio_low', None), 'clip_ratio_high': self.config.get('clip_ratio_high', None)}
             return output, partial(loss_func, data=batch, meta_info=meta_info)
 
         # batch should be a list of batches inside micro-batches

--- a/verl/workers/reward_manager/naive.py
+++ b/verl/workers/reward_manager/naive.py
@@ -15,25 +15,79 @@
 from verl import DataProto
 from verl.utils.reward_score import _default_compute_score
 import torch
+from collections import defaultdict
 
 
 class NaiveRewardManager:
     """The reward manager.
     """
 
-    def __init__(self, tokenizer, num_examine, compute_score=None) -> None:
+    def __init__(self,
+                 tokenizer,
+                 num_examine,
+                 compute_score=None,
+                 reward_fn_key='data_source',
+                 max_response_length=None,
+                 overlong_buffer_cfg=None) -> None:
         self.tokenizer = tokenizer
         self.num_examine = num_examine  # the number of batches of decoded responses to print to the console
         self.compute_score = compute_score or _default_compute_score
+        self.reward_fn_key = reward_fn_key
+        self.overlong_buffer_cfg = overlong_buffer_cfg
+        self.max_response_length = max_response_length
 
-    def __call__(self, data: DataProto):
+        if self.overlong_buffer_cfg is not None:
+            assert self.max_response_length is not None, f"max_response_length must be provided if {overlong_buffer_cfg=}, but got None"
+
+    # TODO: Is this still necessary in algorithms other than PRIME?
+    def verify(self, data):
+        scores = []
+        for i in range(len(data)):
+            data_item = data[i]  # DataProtoItem
+
+            prompt_ids = data_item.batch['prompts']
+
+            prompt_length = prompt_ids.shape[-1]
+
+            valid_prompt_length = data_item.batch['attention_mask'][:prompt_length].sum()
+            valid_prompt_ids = prompt_ids[-valid_prompt_length:]
+
+            response_ids = data_item.batch['responses']
+            valid_response_length = data_item.batch['attention_mask'][prompt_length:].sum()
+            valid_response_ids = response_ids[:valid_response_length]
+
+            # decode
+            prompt_str = self.tokenizer.decode(valid_prompt_ids)
+            response_str = self.tokenizer.decode(valid_response_ids)
+
+            ground_truth = data_item.non_tensor_batch['reward_model']['ground_truth']
+
+            data_source = data_item.non_tensor_batch[self.reward_fn_key]
+
+            extra_info = data_item.non_tensor_batch.get('extra_info', None)
+
+            score = self.compute_score(
+                data_source=data_source,
+                solution_str=response_str,
+                ground_truth=ground_truth,
+                extra_info=extra_info,
+            )
+            scores.append(score)
+        data.batch['acc'] = torch.tensor(scores, dtype=torch.float32, device=prompt_ids.device)
+        return scores
+
+    def __call__(self, data: DataProto, return_dict: bool = False):
         """We will expand this function gradually based on the available datasets"""
 
         # If there is rm score, we directly return rm score. Otherwise, we compute via rm_score_fn
         if 'rm_scores' in data.batch.keys():
-            return data.batch['rm_scores']
+            if return_dict:
+                return {"reward": data.batch['rm_scores']}
+            else:
+                return data.batch['rm_scores']
 
         reward_tensor = torch.zeros_like(data.batch['responses'], dtype=torch.float32)
+        reward_extra_info = defaultdict(list)
 
         already_print_data_sources = {}
 
@@ -52,28 +106,67 @@ class NaiveRewardManager:
             valid_response_ids = response_ids[:valid_response_length]
 
             # decode
-            sequences = torch.cat((valid_prompt_ids, valid_response_ids))
-            sequences_str = self.tokenizer.decode(sequences)
+            prompt_str = self.tokenizer.decode(valid_prompt_ids)
+            response_str = self.tokenizer.decode(valid_response_ids)
+            eos_token = self.tokenizer.eos_token
+            if response_str.endswith(eos_token):
+                response_str = response_str[:-len(eos_token)]
 
             ground_truth = data_item.non_tensor_batch['reward_model']['ground_truth']
 
-            data_source = data_item.non_tensor_batch['data_source']
+            data_source = data_item.non_tensor_batch[self.reward_fn_key]
 
             extra_info = data_item.non_tensor_batch.get('extra_info', None)
 
-            score = self.compute_score(
+            result = self.compute_score(
                 data_source=data_source,
-                solution_str=sequences_str,
+                solution_str=response_str,
                 ground_truth=ground_truth,
                 extra_info=extra_info,
             )
-            reward_tensor[i, valid_response_length - 1] = score
+
+            score: float
+            if isinstance(result, dict):
+                score = result["score"]
+                # Store the information including original reward
+                for key, value in result.items():
+                    reward_extra_info[key].append(value)
+            else:
+                score = result
+
+            reward = score
+
+            if self.overlong_buffer_cfg.enable:
+                overlong_buffer_len = self.overlong_buffer_cfg.len
+                expected_len = self.max_response_length - overlong_buffer_len
+                exceed_len = valid_response_length - expected_len
+                overlong_penalty_factor = self.overlong_buffer_cfg.penalty_factor
+                overlong_reward = min(-exceed_len / overlong_buffer_len * overlong_penalty_factor, 0)
+                reward += overlong_reward
+                if self.overlong_buffer_cfg.log:
+                    reward_extra_info["overlong_reward"].append(overlong_reward)
+                    reward_extra_info["overlong"].append(overlong_reward < 0)
+
+            reward_tensor[i, valid_response_length - 1] = reward
 
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0
 
             if already_print_data_sources[data_source] < self.num_examine:
                 already_print_data_sources[data_source] += 1
-                print(sequences_str)
+                print("[prompt]", prompt_str)
+                print("[response]", response_str)
+                print("[ground_truth]", ground_truth)
+                if isinstance(result, dict):
+                    for key, value in result.items():
+                        print(f"[{key}]", value)
+                else:
+                    print(f"[score]", score)
 
-        return reward_tensor
+        if return_dict:
+            return {
+                "reward_tensor": reward_tensor,
+                "reward_extra_info": reward_extra_info,
+            }
+        else:
+            return reward_tensor

--- a/verl/workers/reward_manager/naive.py
+++ b/verl/workers/reward_manager/naive.py
@@ -16,6 +16,7 @@ from verl import DataProto
 from verl.utils.reward_score import _default_compute_score
 import torch
 from collections import defaultdict
+from tqdm import tqdm
 
 
 class NaiveRewardManager:
@@ -91,7 +92,7 @@ class NaiveRewardManager:
 
         already_print_data_sources = {}
 
-        for i in range(len(data)):
+        for i in tqdm(range(len(data)), desc="Computing reward"):
             data_item = data[i]  # DataProtoItem
 
             prompt_ids = data_item.batch['prompts']


### PR DESCRIPTION
## Summary of Changes

This PR adds the following features:

### 1. Clip-higher  
Allows different values to be set for the lower and upper bounds of the PPO clipping range.  
To use:
```bash
++actor_rollout_ref.actor.clip_ratio_low=0.2  
++actor_rollout_ref.actor.clip_ratio_high=0.28
```
### 2. Soft Overlong Punishment
Penalizes responses that exceed a specified length, encouraging more concise outputs.
To enable:
```bash
++reward_model.reward_manager.overlong_buffer.enable=True  
++reward_model.reward_manager.overlong_buffer.len=2048  
++reward_model.reward_manager.overlong_buffer.penalty_factor=1.0
```
*Note*: Maximum generation length is still defined by:
`++data.max_response_length=6144`

### 3. Dynamic Sampling (with Group Filtering)
Supports resampling prompt groups whose generated responses are not diverse enough (i.e., all share the same reward/accuracy/etc).

*Core logic:*
- Generate gen_batch_size prompts.
- Group outputs by prompt.
- Discard groups where all outputs have the same metric (e.g., all acc=1).
- Repeat sampling until train_batch_size worth of diverse prompts are collected or a retry limit is reached.
```bash
++data.gen_batch_size=1536  
++data.train_batch_size=512  
++algorithm.filter_groups.enable=True  
++algorithm.filter_groups.metric=seq_reward  
++algorithm.filter_groups.max_num_gen_batches=10
```

*Notes:*
If filtering is disabled, `gen_batch_size` must equal `train_batch_size`.


### Breaking changes
To correctly log validation metrics, reward functions *must* return a dict of `score`, `acc`, `pred`, each of which is a list.

